### PR TITLE
chore: align package version to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coupon-simulator-backend",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "coupon-simulator-backend",
-      "version": "1.0.0",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "dotenv": "^17.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coupon-simulator-backend",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Backend for coupon simulator",
   "main": "dist/server.js",
   "scripts": {


### PR DESCRIPTION
Align package.json version with v0.2.0 release tag. No functional changes.